### PR TITLE
Compatibility with kaminari 1.0.1

### DIFF
--- a/lib/kaminari-cells.rb
+++ b/lib/kaminari-cells.rb
@@ -3,17 +3,19 @@ require "kaminari"
 require "kaminari/cells/version"
 require "cell/partial"
 
-module Kaminari
-  module Helpers
-    module CellsHelper
-      include Kaminari::ActionViewExtension
-      include ActionView::Helpers::OutputSafetyHelper
-      include ActionView::Helpers::TranslationHelper
-      include Cell::ViewModel::Partial
+ActiveSupport.on_load :action_view do
+  module Kaminari
+    module Helpers
+      module CellsHelper
+        include Kaminari::ActionViewExtension
+        include ActionView::Helpers::OutputSafetyHelper
+        include ActionView::Helpers::TranslationHelper
+        include Cell::ViewModel::Partial
 
-      def paginate(scope, options = {}, &block)
-        options = options.reverse_merge(:views_prefix => "../views/")
-        super
+        def paginate(scope, options = {}, &block)
+          options = options.reverse_merge(:views_prefix => "../views/")
+          super
+        end
       end
     end
   end


### PR DESCRIPTION
Kaminari 1.0.1 only charge ActionViewExtension if ActiveSupport load so kaminari cell need do same.