### PR TITLE
Fix compatibility with Ruby 3

### DIFF
--- a/lib/kaminari-cells.rb
+++ b/lib/kaminari-cells.rb
@@ -12,7 +12,7 @@ ActiveSupport.on_load :action_view do
         include ActionView::Helpers::TranslationHelper
         include Cell::ViewModel::Partial
 
-        def paginate(scope, options = {}, &block)
+        def paginate(scope, **options, &block)
           options = options.reverse_merge(:views_prefix => "../views/")
           super
         end

--- a/test/fake_app/rails_app.rb
+++ b/test/fake_app/rails_app.rb
@@ -4,7 +4,7 @@ require "cells-rails"
 require 'kaminari-cells'
 
 require 'action_controller/railtie'
-require 'action_view/railtie'
+require 'action_view/base'
 require 'active_record'
 
 # config


### PR DESCRIPTION
Kaminari expects keyword arguments for it's `paginate` helper so we should expect that too.