### PR TITLE
Move require of kaminari/cells into ActionView load hook

### DIFF
--- a/lib/kaminari-cells.rb
+++ b/lib/kaminari-cells.rb
@@ -19,6 +19,5 @@ ActiveSupport.on_load :action_view do
       end
     end
   end
+  require 'kaminari/cells'
 end
-
-require 'kaminari/cells'


### PR DESCRIPTION
Previously when eager loading a rails application using zeitwerk, the
Kaminari::Helpers::CellsHelper module was included before it was defined
by the load hook.

Example:
```
rails zeitwerk:check
Hold on, I am eager loading the application.
rails aborted!
NameError: uninitialized constant Kaminari::Helpers::CellsHelper
```

I'm not sure if this is a proper solution to this problem.