### PR TITLE
Remove ActiveSupport on_load hook

### DIFF
--- a/lib/kaminari-cells.rb
+++ b/lib/kaminari-cells.rb
@@ -3,21 +3,20 @@ require "kaminari/helpers/helper_methods"
 require "kaminari/cells/version"
 require "cell/partial"
 
-ActiveSupport.on_load :action_view do
-  module Kaminari
-    module Helpers
-      module CellsHelper
-        include Kaminari::Helpers::HelperMethods
-        include ActionView::Helpers::OutputSafetyHelper
-        include ActionView::Helpers::TranslationHelper
-        include Cell::ViewModel::Partial
+module Kaminari
+  module Helpers
+    module CellsHelper
+      include Kaminari::Helpers::HelperMethods
+      include ActionView::Helpers::OutputSafetyHelper
+      include ActionView::Helpers::TranslationHelper
+      include Cell::ViewModel::Partial
 
-        def paginate(scope, **options, &block)
-          options = options.reverse_merge(:views_prefix => "../views/")
-          super
-        end
+      def paginate(scope, **options, &block)
+        options = options.reverse_merge(:views_prefix => "../views/")
+        super
       end
     end
   end
-  require 'kaminari/cells'
 end
+
+require 'kaminari/cells'


### PR DESCRIPTION
Since we now use `Kaminari::Helpers::HelperMethods` instead of `Kaminari::ActionViewExtension` it should be safe to remove the ActionView load hook. This load hook led to some headaches if cells were loaded before ActionView.